### PR TITLE
Don't use custom error output code

### DIFF
--- a/create_s3_bucket.py
+++ b/create_s3_bucket.py
@@ -2,27 +2,21 @@ import boto3
 import sys
 
 def create_bucket(region, accessKey, secretKey, bucketName):
+    # Connect to the s3 API
+    s3_bucket = boto3.client('s3',
+                            region_name = region,
+                            aws_access_key_id = accessKey,
+                            aws_secret_access_key = secretKey)
 
-    try:
-        # Connect to the s3 API
-        s3_bucket = boto3.client('s3',
-                                region_name = region,
-                                aws_access_key_id = accessKey,
-                                aws_secret_access_key = secretKey)
-
-        # Create a new bucket with the ACL as private and your specified bucket name
-        new_bucket = s3_bucket.create_bucket(
-            Bucket=bucketName,
-            ACL = 'private',
-        )
-    
-    except Exception as e:
-        print(e)
-
-region = sys.argv[1]
-accessKey = sys.argv[2]
-secretKey = sys.argv[3]
-bucketName = sys.argv[4]
+    # Create a new bucket with the ACL as private and your specified bucket name
+    new_bucket = s3_bucket.create_bucket(
+        Bucket=bucketName,
+        ACL = 'private',
+    )
 
 if __name__ == '__main__':
+    region = sys.argv[1]
+    accessKey = sys.argv[2]
+    secretKey = sys.argv[3]
+    bucketName = sys.argv[4]
     create_bucket(region, accessKey, secretKey, bucketName)


### PR DESCRIPTION
Python's default output for exceptions contains *more* information than `print(e)` since it contains the traceback, which shows you which line failed, as well as the representation of the exception. Contrast:

```
$ # current implementation
$ python -c "try:
>     1/0
> except Exception as e:
>     print(e)"
division by zero
$ # default behaviour
$ python -c '1/0'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
ZeroDivisionError: division by zero
```

And if the code is in files, the traceback is even longer...

Came here from reddit, keep up the studies :)